### PR TITLE
fix: Docker build and publish pushes wrong tag

### DIFF
--- a/.github/actions/create-release/action.yaml
+++ b/.github/actions/create-release/action.yaml
@@ -1,5 +1,4 @@
 name: Create Release
-
 description: Create a release using GitHub CLI
 
 inputs:

--- a/.github/actions/create-tag/action.yaml
+++ b/.github/actions/create-tag/action.yaml
@@ -1,6 +1,10 @@
 name: Create Tag
-
 description: Create and push a new tag
+
+outputs:
+  tag:
+    description: The newly created version tag
+    value: ${{ steps.tag.outputs.tag }}
 
 runs:
   using: composite

--- a/.github/actions/docker-build-and-publish/action.yaml
+++ b/.github/actions/docker-build-and-publish/action.yaml
@@ -1,6 +1,10 @@
 name: Build
-
 description: Build and publish a Docker container
+
+inputs:
+  tag:
+    description: The version tag for the docker image
+    required: true
 
 runs:
   using: composite
@@ -15,20 +19,10 @@ runs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        tags: |
-          type=ref,event=branch
-          type=raw,value=${{ steps.tag.outputs.tag }},enable=${{ github.ref == 'refs/heads/main' }}
-
     - name: Build and push Docker image
       id: push
       uses: docker/build-push-action@v6
       with:
         context: .
         push: ${{ github.ref == 'refs/heads/main' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,17 +23,27 @@ jobs:
 
     steps:
       - name: Checkout repository
+        id: step-checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches
 
-      - uses: simonjensen/pipelines/.github/actions/create-tag@main
+      - name: Create Tag
+        id: step-create-tag
+        uses: simonjensen/pipelines/.github/actions/create-tag@main
 
-      - uses: simonjensen/pipelines/.github/actions/create-release-notes@main
+      - name: Create Release Notes
+        id: step-create-release-notes
+        uses: simonjensen/pipelines/.github/actions/create-release-notes@main
 
-      - uses: simonjensen/pipelines/.github/actions/create-release@main
+      - name: Create Release
+        id: step-create-release
+        uses: simonjensen/pipelines/.github/actions/create-release@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: simonjensen/pipelines/.github/actions/docker-build-and-publish@main
-
+      - name: Docker Build And Release
+        id: step-docker-build-and-release
+        uses: simonjensen/pipelines/.github/actions/docker-build-and-publish@main
+        with:
+          tag: ${{ steps.step-create-tag.outputs.tag }}


### PR DESCRIPTION
The Docker build and publish action now uses the generated output from the tag creation action

Fixes #3 